### PR TITLE
Implement events API and frontend

### DIFF
--- a/backend/src/models/RichText.ts
+++ b/backend/src/models/RichText.ts
@@ -103,6 +103,11 @@ RichTextStep.init(
     }
 );
 
+RichTextSnapshot.hasMany(RichTextStep, { foreignKey: "snapshotId" });
+RichTextStep.belongsTo(RichTextSnapshot, { foreignKey: "snapshotId" });
+
+export { RichTextSnapshot, RichTextStep };
+
 
 
 

--- a/backend/src/routes/api/api.ts
+++ b/backend/src/routes/api/api.ts
@@ -1,6 +1,7 @@
 import express from "express";
 
 import authRouter from "./auth.js";
+import eventsRouter from "./events.js";
 const router = express.Router();
 
 router.get("/", (req, res) => {
@@ -8,5 +9,6 @@ router.get("/", (req, res) => {
 });
 
 router.use("/auth", authRouter);
+router.use("/events", eventsRouter);
 
 export default router;

--- a/backend/src/routes/api/events.ts
+++ b/backend/src/routes/api/events.ts
@@ -1,0 +1,25 @@
+import express from "express";
+import { ensureAuthenticated } from "./auth.js";
+import * as eventService from "../../services/event.js";
+
+const router = express.Router();
+
+router.get("/", ensureAuthenticated, async (_req, res) => {
+  const events = await eventService.getAllEvents();
+  res.status(200).json(events);
+});
+
+router.post("/", ensureAuthenticated, async (req, res) => {
+  const { eventName, startDatetime, endDatetime, description } = req.body;
+  const ownerId = req.user!.id;
+  const event = await eventService.createEvent(
+    ownerId,
+    eventName,
+    new Date(startDatetime),
+    new Date(endDatetime),
+    description || {}
+  );
+  res.status(200).json(event);
+});
+
+export default router;

--- a/backend/src/services/event.ts
+++ b/backend/src/services/event.ts
@@ -1,0 +1,43 @@
+import Event from "../models/Event.js";
+import { RichTextSnapshot } from "../models/RichText.js";
+import { randomBytes } from "crypto";
+import ORM from "../data/ORM.js";
+
+export const getAllEvents = async () => {
+  return Event.findAll({ order: [["startDatetime", "ASC"]] });
+};
+
+export const createEvent = async (
+  ownerId: number,
+  eventName: string,
+  startDatetime: Date,
+  endDatetime: Date,
+  description: object
+) => {
+  return ORM.transaction(async (t) => {
+    const event = await Event.create(
+      {
+        ownerId,
+        eventName,
+        descriptionId: 0,
+        startDatetime,
+        endDatetime,
+        hash: randomBytes(16).toString("hex"),
+      },
+      { transaction: t }
+    );
+    const snapshot = await RichTextSnapshot.create(
+      {
+        ownerType: "event",
+        ownerId: event.id!,
+        version: 1,
+        docJson: description,
+        createdBy: ownerId,
+      },
+      { transaction: t }
+    );
+    event.descriptionId = snapshot.id!;
+    await event.save({ transaction: t });
+    return event;
+  });
+};

--- a/frontend/src/apis/events.ts
+++ b/frontend/src/apis/events.ts
@@ -1,0 +1,15 @@
+import type { Event } from "@/models/Event";
+import { getJson, postJson } from "./common";
+
+export const getEvents = async (): Promise<Event[]> => {
+  return (await getJson<Event[]>("/api/events")) as Event[];
+};
+
+export const createEvent = async (payload: {
+  eventName: string;
+  startDatetime: string;
+  endDatetime: string;
+  description?: object;
+}): Promise<Event> => {
+  return (await postJson<Event>("/api/events", payload)) as Event;
+};

--- a/frontend/src/components/Navigation.vue
+++ b/frontend/src/components/Navigation.vue
@@ -2,6 +2,7 @@
   <nav>
     <span>Introduction</span>
     <RouterLink to="/">Home</RouterLink>
+    <RouterLink to="/events">Events</RouterLink>
   </nav>
 </template>
 

--- a/frontend/src/models/Event.ts
+++ b/frontend/src/models/Event.ts
@@ -1,0 +1,9 @@
+export interface Event {
+  id: number;
+  hash: string;
+  ownerId: number;
+  eventName: string;
+  descriptionId: number;
+  startDatetime: string;
+  endDatetime: string;
+}

--- a/frontend/src/repositories/events.ts
+++ b/frontend/src/repositories/events.ts
@@ -1,0 +1,43 @@
+import { toRef } from "vue";
+import type { Ref } from "vue";
+import { useEventsStore } from "@/stores/events";
+import * as eventsApi from "@/apis/events";
+import type { Event } from "@/models/Event";
+
+class EventsRepository {
+  private store = useEventsStore();
+
+  updateEvents = async (): Promise<void> => {
+    this.store.events = await eventsApi.getEvents();
+  };
+
+  getEvents = (): Ref<Event[] | undefined> => {
+    if (this.store.events === undefined) {
+      this.updateEvents();
+    }
+    return toRef(this.store, "events");
+  };
+
+  createEvent = async (payload: {
+    eventName: string;
+    startDatetime: string;
+    endDatetime: string;
+    description?: object;
+  }): Promise<void> => {
+    const event = await eventsApi.createEvent(payload);
+    if (this.store.events) {
+      this.store.events.push(event);
+    } else {
+      this.store.events = [event];
+    }
+  };
+}
+
+let eventsRepository: EventsRepository | null = null;
+
+export const useEventsRepository = (): EventsRepository => {
+  if (!eventsRepository) {
+    eventsRepository = new EventsRepository();
+  }
+  return eventsRepository;
+};

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router";
 import HomeView from "../views/HomeView.vue";
+import EventsView from "../views/EventsView.vue";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -8,6 +9,11 @@ const router = createRouter({
       path: "/",
       name: "home",
       component: HomeView,
+    },
+    {
+      path: "/events",
+      name: "events",
+      component: EventsView,
     },
   ],
 });

--- a/frontend/src/services/events.ts
+++ b/frontend/src/services/events.ts
@@ -1,0 +1,24 @@
+import type { Ref } from "vue";
+import { useEventsRepository } from "@/repositories/events";
+import type { Event } from "@/models/Event";
+
+export class EventsService {
+  private repository = useEventsRepository();
+
+  getEvents = (): Ref<Event[] | undefined> => {
+    return this.repository.getEvents();
+  };
+
+  createEvent = async (payload: {
+    eventName: string;
+    startDatetime: string;
+    endDatetime: string;
+    description?: object;
+  }): Promise<void> => {
+    await this.repository.createEvent(payload);
+  };
+}
+
+export const useEventsService = (): EventsService => {
+  return new EventsService();
+};

--- a/frontend/src/stores/events.ts
+++ b/frontend/src/stores/events.ts
@@ -1,0 +1,8 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import type { Event } from "@/models/Event";
+
+export const useEventsStore = defineStore("events", () => {
+  const events = ref<Event[] | undefined>(undefined);
+  return { events };
+});

--- a/frontend/src/views/EventsView.vue
+++ b/frontend/src/views/EventsView.vue
@@ -1,0 +1,51 @@
+<template>
+  <main>
+    <h2 class="highlight">Events</h2>
+    <div v-if="user">
+      <form @submit.prevent="create">
+        <input v-model="name" placeholder="Event name" />
+        <input v-model="start" type="datetime-local" />
+        <input v-model="end" type="datetime-local" />
+        <button>Create</button>
+      </form>
+      <ul>
+        <li v-for="ev in events" :key="ev.id">
+          {{ ev.eventName }} ({{ ev.startDatetime }} - {{ ev.endDatetime }})
+        </li>
+      </ul>
+    </div>
+    <div v-else>Please log in to manage events.</div>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { useEventsService } from "@/services/events";
+import { useAuthService } from "@/services/auth";
+
+const eventsService = useEventsService();
+const authService = useAuthService();
+const events = eventsService.getEvents();
+const user = authService.getUser();
+
+const name = ref("");
+const start = ref("");
+const end = ref("");
+
+const create = async () => {
+  await eventsService.createEvent({
+    eventName: name.value,
+    startDatetime: start.value,
+    endDatetime: end.value,
+  });
+  name.value = "";
+  start.value = "";
+  end.value = "";
+};
+</script>
+
+<style scoped>
+form {
+  margin-bottom: 1em;
+}
+</style>


### PR DESCRIPTION
## Summary
- finish rich text model exports
- add events service and routes to backend
- expose events endpoints via API router
- add Vue models, services, repositories, and store for events
- implement simple events view and router entry
- expose navigation link

## Testing
- `npm run build --prefix backend` *(fails: Cannot find module 'dotenv' ...)*
- `npm run build --prefix frontend` *(fails: vue-tsc not found)*